### PR TITLE
ci: add macos for github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
 
       - run: yarn --frozen-lockfile --network-timeout 500000
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn eslint
       - run: yarn build
       - uses: microsoft/playwright-github-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [14.x, 15.x]
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
 
-      - run: yarn --frozen-lockfile --network-timeout 1000000
+      - run: yarn --frozen-lockfile --network-timeout 500000
       - run: yarn eslint
       - run: yarn build
       - uses: microsoft/playwright-github-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
 
-      - run: yarn --frozen-lockfile
+      - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: yarn eslint
       - run: yarn build
       - uses: microsoft/playwright-github-action@v1


### PR DESCRIPTION
Due to the GitHub Action restriction, I can not re-run it in [the PR of the upstream repository ](https://github.com/conwnet/github1s/pull/215).

Let's try it again in my own repository when the test passed.